### PR TITLE
Fix bugs due to static

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,3 +42,15 @@ python -m rerun_robotics.examples.panda
 ```
 
 [Source code](rerun_robotics/examples/panda.py)
+
+## Troubleshooting
+
+If you are having issues, try to install the most recent version of the rerun-sdk (`pip install rerun-sdk -U`). The APIs
+are mostly stable but still change sometimes. If you still are unable to get things working, please open an issue and we
+will do our best to help!
+
+Last tested on `rerun-sdk==0.17.0`.
+
+## Changelog
+
+See [docs/CHANGELOG.md](docs/CHANGELOG.md).

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ pip install -e .
 ```
 
 ## Usage
+
 Check the [Rerun documentation](https://www.rerun.io/docs) for information on how to use the viewer.
 
 We currently support the Franka Emika Panda robot and setting it via joint positions.
@@ -36,6 +37,8 @@ panda.set_joint_positions([0, -0.75, 0, -2.35, 0, 1.57, 0.78, 0.04])
 <img src="https://github.com/williamshen-nz/rerun-robotics/blob/main/docs/panda_example.png?raw=true" width="550">
 
 ### Franka Panda Demo
+
+This demo shows how to log joint positions over time using a [timeline](https://rerun.io/docs/concepts/timelines).
 
 ```bash
 python -m rerun_robotics.examples.panda

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+### v0.0.5
+
+Fixed the Panda demo.
+
+**Breaking Changes**
+
+The signature and behavior of `rerun_robotics.rerun_urdf.log_scene` has been changed
+
+- The `timeless` parameter has been
+  renamed `static`, as `timeless` has been deprecated by rerun as of version `0.16.0`.
+- We log the mesh as `static=True`, so we don't unnecessarily log it again in the future.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "rerun-robotics"
-version = "0.0.4"
+version = "0.0.5"
 description = "Robotics visualization using Rerun"
 readme = "README.md"
 requires-python = ">=3.8"
@@ -17,7 +17,7 @@ classifiers = [
 dependencies = [
     "numpy",
     "pybullet",
-    "rerun-sdk",
+    "rerun-sdk>=0.16.0",
     "trimesh",
     "tqdm",
     "yourdfpy",

--- a/rerun_robotics/franka_panda.py
+++ b/rerun_robotics/franka_panda.py
@@ -37,8 +37,8 @@ class PandaRerun:
 
     def __init__(self, urdf: URDF):
         self._urdf = urdf
-        rr.log("panda_link0", rr.ViewCoordinates.RIGHT_HAND_Z_UP, timeless=True)
-        log_scene(scene=urdf.scene, node="panda_link0", path="panda", timeless=True)
+        rr.log("panda_link0", rr.ViewCoordinates.RIGHT_HAND_Z_UP, static=True)
+        log_scene(scene=urdf.scene, node="panda_link0", path="panda", static=False, add_mesh=True)
 
     @property
     def joint_positions(self) -> np.ndarray:
@@ -50,7 +50,7 @@ class PandaRerun:
                 f"We only support setting 7 arm joints + 1 gripper joints, not {len(joint_positions)} joints"
             )
         self._urdf.update_cfg(joint_positions)
-        log_scene(scene=self._urdf.scene, node="panda_link0", path="panda", timeless=False, add_mesh=False)
+        log_scene(scene=self._urdf.scene, node="panda_link0", path="panda", static=False, add_mesh=False)
 
 
 def load_franka_panda(initial_joint_positions=panda_neutral_joint_positions) -> PandaRerun:

--- a/rerun_robotics/utils.py
+++ b/rerun_robotics/utils.py
@@ -1,6 +1,7 @@
 import numpy as np
 import open3d as o3d
 import rerun as rr
+import trimesh
 
 
 def clean_rerun_path(path: str) -> str:
@@ -13,3 +14,38 @@ def o3d_point_cloud_to_rerun(pcd: o3d.geometry.PointCloud, point_size: float = 0
     positions = np.asarray(pcd.points)
     colors = np.asarray(pcd.colors)
     return rr.Points3D(positions, colors=colors, radii=point_size)
+
+
+def trimesh_to_rerun(geometry: trimesh.PointCloud | trimesh.Trimesh):
+    if isinstance(geometry, trimesh.PointCloud):
+        return rr.Points3D(positions=geometry.vertices, colors=geometry.colors)
+    elif isinstance(geometry, trimesh.Trimesh):
+        # If trimesh gives us a single vertex color for the entire mesh, we can interpret that
+        # as an albedo factor for the whole primitive.
+        mesh = geometry
+        vertex_colors = None
+        mesh_material = None
+        if hasattr(mesh.visual, "vertex_colors"):
+            colors = mesh.visual.vertex_colors
+            if len(colors) == 4:
+                # If trimesh gives us a single vertex color for the entire mesh, we can interpret that
+                # as an albedo factor for the whole primitive.
+                mesh_material = rr.Material(albedo_factor=np.array(colors))
+            else:
+                vertex_colors = colors
+        elif hasattr(mesh.visual, "material"):
+            # There are other properties in trimesh material, but rerun only supports albedo
+            trimesh_material = mesh.visual.material
+            mesh_material = rr.Material(albedo_factor=trimesh_material.main_color)
+        else:
+            raise NotImplementedError("Couldn't determine mesh color or material")
+
+        return rr.Mesh3D(
+            vertex_positions=mesh.vertices,
+            vertex_colors=vertex_colors,
+            vertex_normals=mesh.vertex_normals,
+            triangle_indices=mesh.faces,
+            mesh_material=mesh_material,
+        )
+    else:
+        raise NotImplementedError(f"Unsupported trimesh geometry: {type(geometry)}")


### PR DESCRIPTION
- Makes panda example work again, due to issues with timeless/static
- Log mesh as static by default
- Sets minimum `rerun-sdk` requirement