### PR TITLE
Adds open3d to list of dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ classifiers = [
 
 dependencies = [
     "numpy",
+    "open3d",
     "pybullet",
     "rerun-sdk>=0.18.0",
     "trimesh",


### PR DESCRIPTION
Running the example `python -m rerun_robotics.examples.panda` throws `ModuleNotFoundError: No module named 'open3d'`.

This PR adds `open3d` to `pyproject.toml`.